### PR TITLE
Implemented merging default cloudinit and ssh key with a custom cloudinit, fixes #27

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -71,6 +71,14 @@
       "mode": "debug",
       "program": "main.go",
       "args": ["vm", "create",  "--vm-image-id", "image-7jrrf", "-c", "4", "-m", "2Gi", "-d", "50Gi", "--net", "vlan1", "overcommit-test"]
+    },
+    {
+      "name": "vm creation with userdata",
+      "type": "go",
+      "request": "launch",
+      "mode": "debug",
+      "program": "main.go",
+      "args": ["vm", "create",  "--vm-image-id", "image-7jrrf", "-c", "4", "-m", "2Gi", "-d", "50Gi", "--net", "vlan1", "--user-data-file", "/home/mohamed/user-data.yaml" , "overcommit-test"]
     }
   ]
 }

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -517,7 +517,7 @@ func MergeOptionsInUserData(userData string, defaultUserData string, sshKey *v1b
 		return "", err
 	}
 
-	if userDataMap["ssh_authorized_keys"] != nil {
+	if (userDataMap["ssh_authorized_keys"] != nil && sshKey != nil && sshKey != &v1beta1.KeyPair{}) {
 		sshKeyList := userDataMap["ssh_authorized_keys"].([]interface{})
 		sshKeyList = append(sshKeyList, sshKey.Spec.PublicKey)
 

--- a/cmd/common_test.go
+++ b/cmd/common_test.go
@@ -3,7 +3,10 @@ package cmd
 import (
 	"testing"
 
+	"github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
+	"gopkg.in/yaml.v3"
 	"k8s.io/apimachinery/pkg/api/resource"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestHandleCPUOverCommittment(t *testing.T) {
@@ -21,7 +24,7 @@ func TestHandleCPUOverCommittment(t *testing.T) {
 }
 
 func TestHandleMemoryOverCommittment(t *testing.T) {
-	memoryLimit := "4Gi"
+	memoryLimit := "3G"
 	overCommitSettingMap := map[string]int{
 		"cpu":    1600,
 		"memory": 150,
@@ -31,5 +34,50 @@ func TestHandleMemoryOverCommittment(t *testing.T) {
 	result := HandleMemoryOverCommittment(overCommitSettingMap, memoryLimit)
 	if result.ScaledValue(resource.Giga) != 2 {
 		t.Errorf("Expected 2G, got %dM", result.ScaledValue(resource.Mega))
+	}
+}
+
+func TestMergeOptionsInUserData(t *testing.T) {
+	userData := `ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAA ... custom@foo
+packages:
+  - docker
+runcmd:
+  - docker run -d --restart=unless-stopped -p 80:80 rancher/hello-world
+`
+
+	sshKey := &v1beta1.KeyPair{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "test-ssh-key",
+		},
+		Spec: v1beta1.KeyPairSpec{
+			PublicKey: "ssh-rsa AAAAB4MabD2zd3FBBB ... predef@bar",
+		},
+	}
+
+	result, err := MergeOptionsInUserData(userData, defaultCloudInitUserData, sshKey)
+	if err != nil {
+		t.Errorf("Error merging options in user data: %v", err)
+	}
+
+	var resultMap map[string]interface{}
+	err = yaml.Unmarshal([]byte(result), &resultMap)
+	if err != nil {
+		t.Errorf("Error unmarshalling result: %v", err)
+	}
+
+	sshAuthorizedKeys := resultMap["ssh_authorized_keys"].([]interface{})
+	if len(sshAuthorizedKeys) != 2 {
+		t.Errorf("Expected 2 ssh keys, got %d", len(sshAuthorizedKeys))
+	}
+
+	packages := resultMap["packages"].([]interface{})
+	if len(packages) != 2 {
+		t.Errorf("Expected 2 packages, got %d", len(packages))
+	}
+
+	runcmds := resultMap["runcmd"].([]interface{})
+	if len(runcmds) != 4 {
+		t.Errorf("Expected 4 runcmds, got %d", len(runcmds))
 	}
 }

--- a/cmd/vm.go
+++ b/cmd/vm.go
@@ -15,6 +15,7 @@ import (
 	rcmd "github.com/rancher/cli/cmd"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
+	"gopkg.in/yaml.v3"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	k8sresource "k8s.io/apimachinery/pkg/api/resource"
@@ -640,7 +641,6 @@ func buildVMTemplate(ctx *cli.Context, c *harvclient.Clientset,
 
 	var err1 error
 	cloudInitCustomUserData, err1 := getCloudInitData(ctx, "user")
-	vmTemplate = nil
 	if err1 != nil {
 		err = fmt.Errorf("error during getting cloud init user data from Harvester: %w", err1)
 		return
@@ -657,7 +657,7 @@ func buildVMTemplate(ctx *cli.Context, c *harvclient.Clientset,
 		}
 		logrus.Debugf("SSH Key Name %s given does exist!", ctx.String("ssh-keyname"))
 
-	} else {
+	} else if !userDataContainsKey(cloudInitCustomUserData) {
 		sshKey, err1 = setDefaultSSHKey(c, ctx)
 		if err1 != nil {
 			err = fmt.Errorf("error during setting default SSH key: %w", err1)
@@ -665,10 +665,10 @@ func buildVMTemplate(ctx *cli.Context, c *harvclient.Clientset,
 		}
 	}
 
-	if sshKey == nil || sshKey == (&v1beta1.KeyPair{}) {
-		err = fmt.Errorf("no keypair could be defined")
-		return
-	}
+	//if sshKey == nil || sshKey == (&v1beta1.KeyPair{}) {
+	//err = fmt.Errorf("no keypair could be defined")
+	//return
+	//}
 	cloudInitUserData, err := MergeOptionsInUserData(cloudInitCustomUserData, defaultCloudInitUserData, sshKey)
 	if err != nil {
 		err = fmt.Errorf("error during merging cloud init user data: %w", err)
@@ -1126,4 +1126,20 @@ func enrichVMTemplate(c *harvclient.Clientset, ctx *cli.Context, vmTemplate *VMv
 	}
 
 	return nil
+}
+
+// checks if the userData contains the an ssh_authorize_keys entry
+func userDataContainsKey(userData string) bool {
+	var userDataMap map[string]interface{}
+
+	if err := yaml.Unmarshal([]byte(userData), &userDataMap); err != nil {
+		return false
+	}
+
+	if _, ok := userDataMap["ssh_authorized_keys"]; ok {
+		return true
+	}
+
+	return false
+
 }


### PR DESCRIPTION
Implements a simple cloud-init merging capability for whenever a custom userdata is provided:
- the default userdata (installing qemu-agent and running it) is added to any custom cloud-init
- the public key provided by a `-i` flag will be added to the `ssh_authorized_keys` section of the userdata.

Fixes #27

Signed-off-by: Mohamed Belgaied Hassine <belgaied2@hotmail.com>