### PR TITLE
refactor(ioutil): ioutil is deprecated after 1.16

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"net/url"
 	"os"
@@ -69,7 +68,7 @@ type RoleTemplateBinding struct {
 }
 
 func loadAndVerifyCert(path string) (string, error) {
-	caCert, err := ioutil.ReadFile(path)
+	caCert, err := os.ReadFile(path)
 	if err != nil {
 		return "", err
 	}
@@ -107,7 +106,7 @@ func loadConfig(ctx *cli.Context) (config.Config, error) {
 		Servers: make(map[string]*config.ServerConfig),
 	}
 
-	content, err := ioutil.ReadFile(path)
+	content, err := os.ReadFile(path)
 	if os.IsNotExist(err) {
 		return cf, nil
 	} else if err != nil {

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -291,7 +290,7 @@ func getCertFromServer(ctx *cli.Context, cf *config.ServerConfig) (*cliclient.Ma
 
 	defer res.Body.Close()
 
-	content, err := ioutil.ReadAll(res.Body)
+	content, err := os.ReadAll(res.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/vm.go
+++ b/cmd/vm.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 
@@ -1043,7 +1043,7 @@ func getCloudInitData(ctx *cli.Context, scope string) (string, error) {
 	}
 
 	var cloudInitDataBytes []byte
-	if cloudInitDataBytes, err = ioutil.ReadFile(ctx.String(flagName + "-filepath")); err != nil {
+	if cloudInitDataBytes, err = os.ReadFile(ctx.String(flagName + "-filepath")); err != nil {
 		return "", fmt.Errorf("error during reading of cloud-init file: %s", err)
 	}
 	cloudInitDataString = string(cloudInitDataBytes)


### PR DESCRIPTION
Based on:

- [go#40025](https://github.com/golang/go/issues/42025)
- [go#40026](https://github.com/golang/go/issues/42026)